### PR TITLE
Specify custom runtimes only in _APP_FUNCTIONS_CUSTOM_RUNTIMES

### DIFF
--- a/app/config/runtimes.php
+++ b/app/config/runtimes.php
@@ -11,6 +11,11 @@ use Appwrite\Runtimes\Runtime;
 $runtimes = new Runtimes();
 
 /**
+ * Load default runtimes supported by Appwrite by default
+ */
+$allowList = empty(App::getEnv('_APP_FUNCTIONS_RUNTIMES')) ? [] : \explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES'));
+
+/**
  * Load custom runtimes
  */ 
 $customRuntimes = empty(App::getEnv('_APP_FUNCTIONS_CUSTOM_RUNTIMES')) ? [] : \explode(',', App::getEnv('_APP_FUNCTIONS_CUSTOM_RUNTIMES'));
@@ -50,12 +55,8 @@ foreach($uniqueRuntimeNames as $runtimeImageName => $runtimeImageVersions) {
     }
 
     $runtimes->add($customRuntime);
+    array_push($allowList, $runtimeImageName . '-' . $runtimeImageVersion);
 }
-
-/**
- * Load default runtimes supported by Appwrite by default
- */
-$allowList = empty(App::getEnv('_APP_FUNCTIONS_RUNTIMES')) ? [] : \explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES'));
 
 $runtimes = $runtimes->getAll(true, $allowList);
 


### PR DESCRIPTION
Custom runtimes only need to be specified in _APP_FUNCTIONS_CUSTOM_RUNTIMES environment variable.

Example with version (v1):

```
_APP_FUNCTIONS_RUNTIMES="python-3.8,python-3.9"
_APP_FUNCTIONS_CUSTOM_RUNTIMES="custom-runtime-name:v1"
```

Example for `latest`:

```
_APP_FUNCTIONS_RUNTIMES="python-3.8,python-3.9"
_APP_FUNCTIONS_CUSTOM_RUNTIMES="custom-runtime-name"
```

```
_APP_FUNCTIONS_RUNTIMES="python-3.8,python-3.9"
_APP_FUNCTIONS_CUSTOM_RUNTIMES="custom-runtime-name:latest"
```